### PR TITLE
Add parse! to return just the results

### DIFF
--- a/lib/feeder_ex.ex
+++ b/lib/feeder_ex.ex
@@ -22,6 +22,13 @@ defmodule FeederEx do
     :feeder.stream feed_bin, opts
   end
 
+  def parse!(feed_bin) do
+    case :feeder.stream feed_bin, opts do
+      {:ok, feed, _} -> feed
+      :error -> raise "feed could not be parsed"
+    end
+  end
+
   defp opts do
     [event_state:  {nil, []}, event_fun: &FeederEx.Parser.event/2]
   end

--- a/test/feeder_ex_test.exs
+++ b/test/feeder_ex_test.exs
@@ -30,6 +30,11 @@ defmodule FeederExTest do
 
   end
 
+  test "parse! returns just the parsed results on success" do
+    parsed_feed = FeederEx.parse!(File.read!(@sample_file))
+    assert parsed_feed.title == "Liftoff News"
+  end
+
   test "parsing a binary" do
     bin_feed = File.read! @sample_file
     {:ok, feed, _} = FeederEx.parse(bin_feed)


### PR DESCRIPTION
Adds the ability to return just the results to the
user assuming a happy path { :ok, feed, _ } else
raises an exception.

This allows nicer piping of results.. e.g.

HTTPoison.get!(some_url)
|> FeederEx.parse!
|> Enum.map ......
